### PR TITLE
Set `trust proxy` setting to true

### DIFF
--- a/lobby.js
+++ b/lobby.js
@@ -12,6 +12,8 @@ module.exports.Lobby=function(http, config)
 var app = express();
 var rooms = {};
 
+app.set('trust proxy', true);
+
 app.use(cors());
 app.use('/', express.static(__dirname + '/public'));
 


### PR DESCRIPTION
This prevents http/https mismatch when the server is behind a proxy (e.g. Heroku or Cloudflare)

Example error message when trying to connect to a lobby on https://project-f.github.io/F.LF/game/game.html:

> Failed to execute ‘postMessage’ on ‘DOMWindow’: The target origin provided (‘[http://f-lobby.herokuapp.com](http://f-lobby.herokuapp.com)’) does not match the recipient window’s origin (‘[https://f-lobby.herokuapp.com](https://f-lobby.herokuapp.com)’).

> Failed to execute ‘postMessage’ on ‘DOMWindow’: The target origin provided (‘[http://estonia-expo-receptor-screensavers.trycloudflare.com](http://estonia-expo-receptor-screensavers.trycloudflare.com)’) does not match the recipient window’s origin (‘[http://estonia-expo-receptor-screensavers.trycloudflare.com](https://estonia-expo-receptor-screensavers.trycloudflare.com)’).